### PR TITLE
GraphQL should be a peer dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,10 @@
   },
   "license": "MIT",
   "dependencies": {
-    "graphql": "^0.6.0",
     "reflect-metadata": "^0.1.3"
+  },
+  "peerDependencies": {
+    "graphql": "^0.6.0"
   },
   "devDependencies": {
     "dtsm": "^1.1.0",


### PR DESCRIPTION
So that schemas can be used by other instances of GraphQL.
